### PR TITLE
Added LoadData, LoadSGF, LoadGIB, LoadNGF

### DIFF
--- a/all_test.go
+++ b/all_test.go
@@ -660,3 +660,25 @@ func TestForcedMovesEquivalence(t *testing.T) {
 		// node.GetRoot().Save("meh.sgf")
 	}
 }
+
+func TestLoadAndSafeSGFData(t *testing.T) {
+	t.Parallel()
+
+	sgfData := "(;GM[1]FF[4]CA[UTF-8]AP[Sabaki:0.52.2]KM[6.5]SZ[13]DT[2023-03-30];B[aa];W[ba];B[ca])"
+
+	s1, err := LoadData(sgfData, ".sgf")
+	if err != nil {
+		t.Errorf("should parse the sgf contents")
+	}
+	if s1.SGF() != sgfData {
+		t.Errorf("parsed and generated SGF should be the same")
+	}
+
+	s2, err := LoadSGF(sgfData)
+	if err != nil {
+		t.Errorf("should parse the sgf contents")
+	}
+	if s2.SGF() != sgfData {
+		t.Errorf("parsed and generated SGF should be the same")
+	}
+}

--- a/all_test.go
+++ b/all_test.go
@@ -666,19 +666,11 @@ func TestLoadAndSafeSGFData(t *testing.T) {
 
 	sgfData := "(;GM[1]FF[4]CA[UTF-8]AP[Sabaki:0.52.2]KM[6.5]SZ[13]DT[2023-03-30];B[aa];W[ba];B[ca])"
 
-	s1, err := LoadData(sgfData, ".sgf")
+	s, err := LoadSGF(sgfData)
 	if err != nil {
 		t.Errorf("should parse the sgf contents")
 	}
-	if s1.SGF() != sgfData {
-		t.Errorf("parsed and generated SGF should be the same")
-	}
-
-	s2, err := LoadSGF(sgfData)
-	if err != nil {
-		t.Errorf("should parse the sgf contents")
-	}
-	if s2.SGF() != sgfData {
+	if s.SGF() != sgfData {
 		t.Errorf("parsed and generated SGF should be the same")
 	}
 }

--- a/io.go
+++ b/io.go
@@ -136,9 +136,9 @@ func LoadData(data, filename string) (*Node, error) {
 
 	if err != nil {
 		if strings.HasSuffix(strings.ToLower(filename), ".gib") {
-			root, err = load_gib(data)
+			root, err = LoadGIB(data)
 		} else if strings.HasSuffix(strings.ToLower(filename), ".ngf") {
-			root, err = load_ngf(data)
+			root, err = LoadNGF(data)
 		}
 	}
 
@@ -154,12 +154,9 @@ func LoadSGF(sgf string) (*Node, error) {
 	return root, err
 }
 
-func LoadGIB(sgf string) (*Node, error) {
-	return load_gib(sgf)
-}
-
-func LoadNGF(sgf string) (*Node, error) {
-	return load_ngf(sgf)
+func LoadSGFTree(sgf string) (*Node, error) {
+	root, _, err := load_sgf_tree(sgf, nil)
+	return root, err
 }
 
 func load_sgf_tree(sgf string, parent_of_local_root *Node) (*Node, int, error) {

--- a/io.go
+++ b/io.go
@@ -278,22 +278,24 @@ func load_sgf_tree(sgf string, parent_of_local_root *Node) (*Node, int, error) {
 // slice of length 1 will be returned.
 func LoadCollection(filename string) ([]*Node, error) {
 
-	var ret []*Node
-
 	file_bytes, err := ioutil.ReadFile(filename)
 	if err != nil {
-		return ret, err
+		return nil, err
 	}
 
-	data := string(file_bytes)
-	data = strings.TrimSpace(data)		// Otherwise any trailing characters will trigger an extra attempt to read a tree.
+	return LoadSGFCollection(string(file_bytes))
+}
+
+func LoadSGFCollection(sgf string) ([]*Node, error) {
+	var ret []*Node
+	sgf = strings.TrimSpace(sgf)		// Otherwise any trailing characters will trigger an extra attempt to read a tree.
 
 	for {
-		if len(data) == 0 {
+		if len(sgf) == 0 {
 			return ret, nil
 		}
 
-		root, chars_read, err := load_sgf_tree(data, nil)
+		root, chars_read, err := load_sgf_tree(sgf, nil)
 
 		if err != nil {
 			return ret, err
@@ -301,7 +303,7 @@ func LoadCollection(filename string) ([]*Node, error) {
 
 		ret = append(ret, root)
 
-		data = data[chars_read:]
+		sgf = sgf[chars_read:]
 	}
 }
 

--- a/io.go
+++ b/io.go
@@ -125,13 +125,11 @@ func Load(filename string) (*Node, error) {
 	}
 
 	data := string(file_bytes)
-	return LoadData(data, filename)
-}
 
-func LoadData(data, filename string) (*Node, error) {
 	// If RAM wastage was ever an issue, one can do the super-spooky:
 	// data := *(*string)(unsafe.Pointer(&file_bytes))
 	// See https://github.com/golang/go/issues/25484 for details.
+
 	root, _, err := load_sgf_tree(data, nil)
 
 	if err != nil {
@@ -148,7 +146,6 @@ func LoadData(data, filename string) (*Node, error) {
 
 	return root, nil
 }
-
 func LoadSGF(sgf string) (*Node, error) {
 	root, _, err := load_sgf_tree(sgf, nil)
 	return root, err

--- a/io.go
+++ b/io.go
@@ -151,11 +151,6 @@ func LoadSGF(sgf string) (*Node, error) {
 	return root, err
 }
 
-func LoadSGFTree(sgf string) (*Node, error) {
-	root, _, err := load_sgf_tree(sgf, nil)
-	return root, err
-}
-
 func load_sgf_tree(sgf string, parent_of_local_root *Node) (*Node, int, error) {
 
 	// A tree is whatever is between ( and ).

--- a/io.go
+++ b/io.go
@@ -125,11 +125,13 @@ func Load(filename string) (*Node, error) {
 	}
 
 	data := string(file_bytes)
+	return LoadData(data, filename)
+}
 
+func LoadData(data, filename string) (*Node, error) {
 	// If RAM wastage was ever an issue, one can do the super-spooky:
 	// data := *(*string)(unsafe.Pointer(&file_bytes))
 	// See https://github.com/golang/go/issues/25484 for details.
-
 	root, _, err := load_sgf_tree(data, nil)
 
 	if err != nil {
@@ -145,6 +147,18 @@ func Load(filename string) (*Node, error) {
 	}
 
 	return root, nil
+}
+
+func LoadSGF(sgf string) (*Node, error) {
+	return LoadData(sgf, ".sgf")
+}
+
+func LoadGIB(sgf string) (*Node, error) {
+	return LoadData(sgf, ".gib")
+}
+
+func LoadNGF(sgf string) (*Node, error) {
+	return LoadData(sgf, ".ngf")
 }
 
 func load_sgf_tree(sgf string, parent_of_local_root *Node) (*Node, int, error) {

--- a/io.go
+++ b/io.go
@@ -150,15 +150,16 @@ func LoadData(data, filename string) (*Node, error) {
 }
 
 func LoadSGF(sgf string) (*Node, error) {
-	return LoadData(sgf, ".sgf")
+	root, _, err := load_sgf_tree(sgf, nil)
+	return root, err
 }
 
 func LoadGIB(sgf string) (*Node, error) {
-	return LoadData(sgf, ".gib")
+	return load_gib(sgf)
 }
 
 func LoadNGF(sgf string) (*Node, error) {
-	return LoadData(sgf, ".ngf")
+	return load_ngf(sgf)
 }
 
 func load_sgf_tree(sgf string, parent_of_local_root *Node) (*Node, int, error) {

--- a/io_gib.go
+++ b/io_gib.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 )
 
-func load_gib(gib string) (*Node, error) {
+func LoadGIB(gib string) (*Node, error) {
 
 	root := NewTree(19)
 	node := root

--- a/io_ngf.go
+++ b/io_ngf.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 )
 
-func load_ngf(ngf string) (*Node, error) {
+func LoadNGF(ngf string) (*Node, error) {
 
 	ngf = strings.TrimSpace(ngf)
 


### PR DESCRIPTION
I need a way to load the sgf I keep in memory. All the functions calling `load_sgf_tree` load the sgf contents from a file.

This pull request adds public methods around `load_sgf_tree`.